### PR TITLE
!B (Release) Add _RELEASE Define when compiling in release configuration

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -149,6 +149,8 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 	${SDL2_LIB}/SDL2.lib
 	${LIBAV_LIB}/swscale.lib)
 
+target_compile_definitions(${PROJECT_NAME} PUBLIC $<$<CONFIG:RELEASE>:_RELEASE>)
+
 if (WIN32)
 	target_link_libraries(${PROJECT_NAME} PRIVATE Ntdll)
 endif(WIN32)


### PR DESCRIPTION
This allows building in release configuration ;).

Whether this makes sense for 5.4/5.5 I have not checked.
This commit is for 5.3 as _RELEASE is necessary to be defined when building a Release DLL.